### PR TITLE
Feature: Add robust=TRUE option to catHB for WLSMV robust indices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: AGPL-3
 Language: en-US
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Depends: R (>= 4.0.0)
 URL: https://github.com/melissagwolf/dynamic
 BugReports: https://github.com/melissagwolf/dynamic/issues

--- a/man/catHB.Rd
+++ b/man/catHB.Rd
@@ -11,7 +11,8 @@ catHB(
   plot = FALSE,
   manual = FALSE,
   reps = 250,
-  estimator = "WLSMV"
+  estimator = "WLSMV",
+  robust = FALSE
 )
 
 \method{print}{catHB}(x, ...)
@@ -31,7 +32,13 @@ If you manually entered standardized loadings and sample size, set this to TRUE.
 \item{reps}{The number of replications used in your simulation. This is set to 500 by default in both the
 R package and the corresponding Shiny App.}
 
-\item{estimator}{Which estimator to use within the simulations (enter in quotes). The default is WLSMV. Only limited-information estimators that produce fit indices are permitted (i.e., maximum likelihood is not available)}
+\item{estimator}{Which estimator to use within the simulations (enter in quotes). The default is WLSMV. Only limited-information estimators that produce fit indices are permitted (i.e., maximum likelihood is not available).}
+
+\item{robust}{A logical flag. When set to \code{TRUE}, the function will extract and report the \code{.robust}
+fit indices (e.g., \code{rmsea.robust}, \code{cfi.robust}) from \code{lavaan} simulations. This is highly recommended
+when using the \code{WLSMV} estimator to ensure the use of appropriate fit statistics corrected for non-normality,
+as justified by the work of Brosseau-Liard, Savalei, & Li (2012) and Brosseau-Liard & Savalei (2014).
+When \code{FALSE} (the default), the function retains its original behavior, which may report \code{.scaled} fit indices for certain estimators.}
 
 \item{x}{catHB object}
 
@@ -57,9 +64,14 @@ m1<-"
  F1~~F2"
 
  #fit the model in lavaan, treating items are categorical
- fit<-lavaan::cfa(m1, data=Example, ordered=TRUE)
+ fit<-lavaan::cfa(m1, data=Example, ordered=TRUE, estimator="WLSMV")
 
+# Original behavior (robust=FALSE)
 \donttest{catHB(fit)}
+
+# Recommended behavior for WLSMV (robust=TRUE)
+# This will produce different DFI cutoffs and empirical fit indices
+\donttest{catHB(fit, robust=TRUE)}
 
 #Manual entry example (manual=TRUE)
 
@@ -70,17 +82,10 @@ m1<-"
  F1~~F2"
 
  #fit the model, treating items are categorical
- #lavaan is used here to shown where estimates come from
- #but manual entry supports standardized estimates from models fit in any software
+ #lavaan is used here to show where estimates come from
 
  fit<-lavaan::cfa(m1, data=Example, ordered=TRUE)
  lavaan::standardizedsolution(fit)
-
-#thresholds go in model statement as
-  #(a)categorical item name
-  #(b) vertical pipe
-  #(c) estimate
-  #(d)times t+threshold number
 
 manual_model <-"F1=~.448*X1 + .557*X2 + .770*X3
  F2=~.612*X6 + .684*X7 + .736*X8 + .365*X12
@@ -122,6 +127,11 @@ X12 | 0.900*t3
 X12 | 1.392*t4"
 \donttest{catHB(model=manual_model,n=500,manual=TRUE)}
 
+}
+\references{
+Brosseau-Liard, P. E., Savalei, V., & Li, L. (2012). An Investigation of the Sample Performance of Two Nonnormality Corrections for RMSEA. \emph{Multivariate Behavioral Research}, 47(6), 904-930.
+
+Brosseau-Liard, P. E., & Savalei, V. (2014). Adjusting Incremental Fit Indices for Nonnormality. \emph{Multivariate Behavioral Research}, 49(5), 460-470.
 }
 \author{
 Daniel McNeish & Melissa G Wolf


### PR DESCRIPTION
Hi Melissa @melissagwolf and Dan @dmcneish18!
   further to Issue #31, this merge request adds the proposed `robust = TRUE` feature to the `catHB` function.

This change allows users to generate DFI cutoffs and view empirical fit statistics based on the `.robust` values from `lavaan` when using the `WLSMV` estimator. This is implemented as a backward-compatible, opt-in feature.

### Summary of Changes:

*   **Introduced a `robust = FALSE` argument** to `catHB` and all relevant simulation functions in `Helper.R`.
*   **Updated Simulation and Display Logic:** The internal logic in both `catHB.R` and `Helper.R` now respects the `robust` flag, extracting and displaying the correct `.robust` or `.scaled` fit indices as requested.
*   **Updated Documentation:** The Roxygen2 documentation for `catHB` has been updated to explain the new `robust` argument.

### Demonstration of New Functionality

The following reproducible example demonstrates how the updated function works.

```R
# 1. Load necessary packages and prepare data
library(lavaan)
devtools::load_all() # Load the modified 'dynamic' package

data("HolzingerSwineford1939")

set.seed(123)
# Collapse the original 9-point Likert into 4 ordered categories
ord_data <- HolzingerSwineford1939[ , paste0("x", 1:9)]
ord_data[] <- lapply(ord_data,function(z) as.integer(cut(z, breaks = 4)))

# 2. Fit a WLSMV model
HS.model <- '
  visual  =~ x1 + x2 + x3
  textual =~ x4 + x5 + x6
  speed   =~ x7 + x8 + x9
'
fit <- cfa(HS.model,
           data       = ord_data,
           ordered    = TRUE,
           estimator  = "WLSMV")

# 3. Run with default (original) behavior
print("--- Output with robust = FALSE (original behavior) ---")
catHB(fit, reps = 50, robust = FALSE)
# Note: The empirical RMSEA is 0.074, CFI is 0.969 (.scaled values)

# 4. Run with new robust=TRUE option
print("--- Output with robust = TRUE (new functionality) ---")
catHB(fit, reps = 50, robust = TRUE)
# Note: The empirical RMSEA is now 0.103, CFI is 0.92 (.robust values)
```

I hope you find this to be a useful addition. 
Thank you!
Lukas
